### PR TITLE
Add news fetcher script for daily stock updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To run this project, you need to install the following dependencies:
 
 - `requests`
 - `beautifulsoup4`
+- `yfinance`
 
 You can install the required packages using pip:
 
@@ -38,6 +39,16 @@ python src/main.py
 ```
 
 4. Follow the prompts to enter a stock symbol and view the call option data.
+
+### Fetch Daily News
+
+To fetch the latest news and sector information for a set of stocks, run:
+
+```
+python src/fetch_news.py
+```
+
+This script prints the most recent headlines for stocks such as Bajaj Finance, Tata Consumer, PGEL, Titan, Eternal, United Spirits, Havells, Info Edge, PFC, CAMS, CDSL, Cyient, and Mazagon Dock.
 
 ## Contributing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+yfinance

--- a/src/fetch_news.py
+++ b/src/fetch_news.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timezone
+from typing import List
+
+import yfinance as yf
+
+STOCKS: List[str] = [
+    "BAJFINANCE",
+    "TATACONSUM",
+    "PGEL",
+    "TITAN",
+    "ETERNAL",  # TODO: verify correct ticker symbol
+    "MCDOWELL-N",
+    "HAVELLS",
+    "NAUKRI",
+    "PFC",
+    "CAMS",
+    "CDSL",
+    "CYIENT",
+    "MAZDOCK",
+]
+
+
+def fetch_news(symbol: str, items: int = 3) -> None:
+    """Fetch and print recent news for a given stock symbol."""
+    ticker = yf.Ticker(symbol + ".NS")
+
+    try:
+        info = ticker.info
+        sector = info.get("sector", "Unknown")
+    except Exception:
+        sector = "Unknown"
+
+    print(f"{symbol} (Sector: {sector})")
+
+    try:
+        news_list = ticker.news[:items]
+    except Exception as exc:
+        print(f"  Failed to load news: {exc}")
+        print()
+        return
+
+    if not news_list:
+        print("  No recent news found.\n")
+        return
+
+    for item in news_list:
+        publish_time = datetime.fromtimestamp(
+            item.get("providerPublishTime", 0), tz=timezone.utc
+        )
+        time_str = publish_time.strftime("%Y-%m-%d %H:%M UTC")
+        title = item.get("title", "No title")
+        provider = item.get("provider", "")
+        link = item.get("link", "")
+        print(f"  - {time_str} | {title} ({provider})")
+        if link:
+            print(f"    {link}")
+    print()
+
+
+if __name__ == "__main__":
+    for sym in STOCKS:
+        fetch_news(sym)


### PR DESCRIPTION
## Summary
- add `fetch_news.py` to retrieve latest headlines and sector info for key stocks
- document news-fetching script in README
- include `yfinance` dependency

## Testing
- `python src/fetch_news.py` *(fails: CONNECT tunnel failed, response 403)*
- `python -m py_compile src/fetch_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68be62cd03488333956586ba87597db8